### PR TITLE
Implement SafeKeyPipeline armed preparation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/README_snippet.md
+++ b/README_snippet.md
@@ -1,0 +1,17 @@
+# Safe Key Pipeline Quick Notes
+
+## Shift batch configuration
+- Open the userscript header and locate `SAFE_KEYS_CONFIG` near the top of `src/Verter.user.js`.
+- Set `USE_SHIFT_FOR_RESET` and `USE_SHIFT_FOR_GROSS_SET` to `false` to disable Shift batches (the pipeline will continue to work, only slower).
+- Optional: adjust `RESET_SHIFT_BATCH` and `GROSS_SHIFT_BATCH` to tune how many Shift+A/Shift+D presses are sent in each coarse batch.
+
+## Monitoring ARMED status
+- The trading panel now includes a compact indicator "ARMED" with a live status line.
+- **Green** background: amount prepared and verified (shows `$value • Xs ago`).
+- **Yellow** background: amount became DIRTY (reason shown); pipeline automatically schedules a fresh preparation.
+- **Red** background: safety abort. Wait for automatic reset or trigger a manual re-prep.
+- **Blue/Grey** backgrounds: preparation in progress or idle.
+
+## Manual re-preparation
+- If you change instrument or balance manually, the indicator will turn yellow and the bot will re-arm the required amount.
+- You can also call `window.__SAFE_KEYS__.prepareArmed(target)` from the dev console for manual testing when DEV export is enabled.


### PR DESCRIPTION
## Summary
- add the SafeKeyPipeline module with configurable selectors, reset/calibration/prepare flows, and watchdog logging to prepare bets through simulated key presses
- integrate the pipeline with trade logic for asynchronous ARMED verification, single-flight locks, and automatic re-preparation on dirty or symbol change events
- expose an ARMED status indicator in the trading panel and document shift batch tuning in README_snippet.md

## Testing
- npm run pcs

------
https://chatgpt.com/codex/tasks/task_e_68cb3c2b71688332aeeb39aa8b515851