### PR TITLE
Port stake fix mechanics from app18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [5.3.0] - 2025-09-20
+### Added
+- Ported deterministic stake placement module (`AmountGuard`) with payout guard, retry logic, and HUD logging.
+- Introduced trade placement locks, minute-boundary synchronisation, and payout filtering before submitting orders.
+- Added deal observer callback bridge to drive Martingale step updates on actual trade outcomes and soft resets on asset switches.
+
+### Changed
+- Updated Martingale progression to follow real deal closures and integrated compact HUD logs for bets and deal results.
+- Refreshed build metadata to `5.12.0-CAN CHS StakeFix` reflecting stake mechanics improvements.


### PR DESCRIPTION
## Summary
- add AmountGuard module with deterministic amount entry, payout gating, and HUD logging before trades
- introduce single-flight trade locks, minute-boundary waits, and Martingale updates that trigger on actual deal closures
- expose deal observer attachment API, reset amount guard on asset changes, and refresh build metadata plus changelog

## Testing
- npm run syntax
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ceb0277f1483328e26b35beceb30db