### PR TITLE
Improve packaging fallback and virtual trade logging

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -18,11 +18,27 @@ APP=${APPV%% ver*}
 LABEL="OrderGate+VirtFix"
 STAMP=$(date +%Y%m%d-%H%M)
 
+README_SRC="README.md"
+CLEANUP_README=0
+if [[ ! -f "$README_SRC" ]]; then
+  if [[ -f "README_snippet.md" ]]; then
+    cp "README_snippet.md" "$README_SRC"
+    CLEANUP_README=1
+  else
+    echo "ERR: README.md not found" >&2
+    exit 3
+  fi
+fi
+
 OUTDIR="build"
 NAME="${APP}_ver_${VER}_(${LABEL})_${STAMP}.zip"
 
 mkdir -p "$OUTDIR"
-zip -r "${OUTDIR}/${NAME}" "$SRC" README.md >/dev/null
+zip -r "${OUTDIR}/${NAME}" "$SRC" "$README_SRC" >/dev/null
+
+if [[ $CLEANUP_README -eq 1 ]]; then
+  rm "$README_SRC"
+fi
 
 # совместимый алиас
 cp "${OUTDIR}/${NAME}" "${OUTDIR}/Verter_SAFE.zip"

--- a/src/Verter.user.js
+++ b/src/Verter.user.js
@@ -607,7 +607,7 @@ function openVirtualIfFree({ asset, signalId, direction, priceOpen, signalLabel 
 
     const key = _virtKey(asset, signalId);
     if (virtTradesActive.has(key)){
-        console.warn('[VIRT][BLOCK]', 'already active', key);
+        console.warn('[VIRT-BLOCK]', 'already active', key);
         return null;
     }
 
@@ -624,7 +624,7 @@ function openVirtualIfFree({ asset, signalId, direction, priceOpen, signalLabel 
         signalKey: key
     };
 
-    trade.timeoutId = setTimeout(() => closeVirtual(key), 60_000);
+    trade.timeoutId = setTimeout(() => closeVirtual(key), VIRT_TRADE_DURATION);
     virtTradesActive.set(key, trade);
 
     console.log('[VIRT-OPEN]', key, normalizedDirection, openPrice);


### PR DESCRIPTION
## Summary
- ensure the virtual trade duplicate guard logs with the `[VIRT-BLOCK]` tag and relies on the configured timeout constant
- update `pack.sh` to create release archives even when only `README_snippet.md` is present by copying it into place before zipping

## Testing
- ./pack.sh

------
https://chatgpt.com/codex/tasks/task_e_68da649df84883329077b278d70ebebd